### PR TITLE
Fix/1-fix-tree-ui-bug

### DIFF
--- a/view/src/components/Tree/treeUtils.ts
+++ b/view/src/components/Tree/treeUtils.ts
@@ -98,3 +98,45 @@ export const getLifecycleStateStyles = (state: CMState) => {
       return '';
   }
 }
+
+export const areArraysOfObjectsEqual = (
+  ...arrays: [{ [x: string]: ITableData[] }] | any[]
+) => {
+    // Check if lengths are equal
+    const lengthCheck = arrays.every((arr) => arr.length === arrays[0].length);
+    if (!lengthCheck) {
+      return false;
+    }
+
+    // Helper function to compare two objects
+    const areObjectsEqual = (
+      obj1: { [x: string]: { toString: () => any } },
+      obj2: { [x: string]: { toString: () => any } }
+    ) => {
+      const keys1 = Object.keys(obj1);
+      const keys2 = Object.keys(obj2);
+
+      // Check if number of keys is the same
+      if (keys1.length !== keys2.length) {
+        return false;
+      }
+
+      // Check if values for each key are the same
+      return keys1.every(
+        (key) => obj1[key].toString() === obj2[key].toString()
+      );
+    };
+
+    // Check if every object in the first array is present in the other arrays
+    const areArraysEqual = Object.values(arrays[0]).every((obj: any) =>
+      arrays
+        .slice(1)
+        .every((arr) =>
+          arr.some((arrObj: { [x: string]: { toString: () => any } }) =>
+            areObjectsEqual(obj, arrObj)
+          )
+        )
+    );
+
+    return areArraysEqual;
+};


### PR DESCRIPTION
---
name: Pull request
about: Improve this project
title: ''
labels: ''
assignees: ''

---

## Checklist before submitting a merge request

- [x] I have reviewed `CONTRIBUTING.md` document
- [x] All commits have been signed-off for the Developer Certificate of Origin. See [here](/CONTRIBUTING.md#developer-certificate-of-origin).
- [x] I have added my contribution to `CHANGELOG.md`

## Description of contribution

Added VSCode popup for users about possible tree UI bugs in OML Vision

## Testing performed

<!-- If needed, describe additional testing that was performed for any changes -->

- [x] Go to Tree View
- [x] An example is open https://github.com/opencaesar/kepler16b-example/tree/opencaesar-225 and load data into the RDF triplestore
- [x] From there go to the Pages section and open the `Requirements` tab
- [x] Verify that an error popup shows up in the lower right of VSCode
- [x] The popup should show `2 identical keys.  Fix queries & subRowMappings treeLayouts.json`

## Expected functionality changes

The VSCode popup shows `2 identical keys.  Fix queries & subRowMappings treeLayouts.json` 

## Additional context

<img width="1728" alt="image" src="https://github.com/opencaesar/oml-vision/assets/108915844/128a2ba2-e4cc-47b2-9ba3-000b47bdddd4">

