### PR TITLE
add way for users to change animation of edges

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 RUN apt-get install -y openjdk-17-jdk
 
 # Install TypeScript and npm
-RUN npm install -g typescript
+RUN npm install -g typescript yarn
 
 # Install Docker
 RUN apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release && \

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 - [ ] I have reviewed [CONTRIBUTING.md](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md) document
 - [ ] All commits have been signed-off for the Developer Certificate of Origin. See [here](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
 - [ ] I have added my contribution to [CHANGELOG.md](https://github.com/opencaesar/oml-vision/blob/master/CHANGELOG.md)
+- [ ] I have documented my code in the [OML Vision Docs](http://www.opencaesar.io/oml-vision-docs/)
 
 ## Description of contribution
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 - Add export to SVG for diagrams https://github.com/opencaesar/oml-vision/pull/3
 - Add VSCode dev container https://github.com/opencaesar/oml-vision/pull/21
+- Add ability to change node and node text color while automatically changing node color based on node type https://github.com/opencaesar/oml-vision/pull/22
+- Add ability to change edge color and determine if edge is animated https://github.com/opencaesar/oml-vision/pull/23
 
 ## [0.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Add export to SVG for diagrams https://github.com/opencaesar/oml-vision/pull/3
 - Add VSCode dev container https://github.com/opencaesar/oml-vision/pull/21
 - Add ability to change node and node text color while automatically changing node color based on node type https://github.com/opencaesar/oml-vision/pull/22
-- Add ability to change edge color and determine if edge is animated https://github.com/opencaesar/oml-vision/pull/23
+- Add ability to animate edges https://github.com/opencaesar/oml-vision/pull/23
 
 ## [0.1.0]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,13 @@ We thank you for taking time to contribute! We appreciate your help with feature
 
 ## Environment details
 
-Details on how to build and set up the project are available in the [README.md](README.md#developer-instructions).
+Details on how to build and set up the project are available in the [DEVELOPMENT.md](DEVELOPMENT.md).
+
+## API Documentation
+
+API documentation is available in the [OML Vision Docs](http://www.opencaesar.io/oml-vision-docs/).  
+
+**New features and bug fixes must be added to this documentation before new code is merged.**
 
 ## Testing
 

--- a/view/src/components/Diagram/diagramUtils.ts
+++ b/view/src/components/Diagram/diagramUtils.ts
@@ -264,7 +264,12 @@ export const mapDiagramValueData = (
         (node: ITableData) => node.data.edgeKey === edge[edgeMapping.targetKey]
       );
       let flow = edge.flow || "=";
-      let colorIdentifier = edge[edgeMapping.targetKey] || "";
+      let legendItems = edgeMapping.legendItems.replace(
+        /{([^}]+)}/g,
+        (match, placeholder) => {
+          return edge[placeholder] || "";
+        }
+      );
 
       // get the animated from the layout file and default the animated to false 
       const animated = edgeMapping.animated || false;
@@ -279,16 +284,16 @@ export const mapDiagramValueData = (
       if (sourceNode && targetNode) {
         let edgeId = `${sourceNode.id}-${targetNode.id}`;
 
-        // Only add color to the map aka Legend if it exists, otherwise default and don't add to legend.
-        if (colorIdentifier && !colorMap.has(colorIdentifier)) {
-          colorMap.set(colorIdentifier, {
-            color: stringToColor(colorIdentifier),
+        // Only automatically generate color to the map aka Legend if it exists, otherwise default and don't add to legend.
+        if (legendItems && !colorMap.has(legendItems)) {
+          colorMap.set(legendItems, {
+            color: stringToColor(legendItems),
             isEdge: true,
           });
         }
 
-        let color = colorIdentifier
-          ? colorMap.get(colorIdentifier).color
+        let color = legendItems
+          ? colorMap.get(legendItems).color
           : "var(--vscode-banner-foreground)";
 
         let newEdge: Edge = {

--- a/view/src/components/Diagram/diagramUtils.ts
+++ b/view/src/components/Diagram/diagramUtils.ts
@@ -1,8 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import ITableData from "../../interfaces/ITableData";
 import {
-  IRowMapping,
-  DataLayoutsType,
   DiagramLayout,
   IDiagramRowMapping,
   IDiagramEdgeMapping,
@@ -11,7 +9,6 @@ import {
 import {
   Edge,
   MarkerType,
-  Node,
   ReactFlowState,
   useStoreApi,
   Position,
@@ -267,7 +264,11 @@ export const mapDiagramValueData = (
         (node: ITableData) => node.data.edgeKey === edge[edgeMapping.targetKey]
       );
       let flow = edge.flow || "=";
-      let colorIdentifier = edge[edgeMapping.colorKey] || "";
+      let colorIdentifier = edge[edgeMapping.targetKey] || "";
+
+      // get the animated from the layout file and default the animated to false 
+      const animated = edgeMapping.animated || false;
+
       const label = edgeMapping.labelFormat.replace(
         /{([^}]+)}/g,
         (match, placeholder) => {
@@ -293,6 +294,7 @@ export const mapDiagramValueData = (
         let newEdge: Edge = {
           id: edgeId,
           label: label,
+          animated: animated,
           source: sourceNode.id,
           target: targetNode.id,
           style: { stroke: color },
@@ -608,6 +610,7 @@ export const getLayoutedElements = (nodes: ITableData, edges: Edge[]) => {
     edges: edges.map((edge) => ({
       ...edge,
       id: edge.id,
+      animated: edge.animated,
       sources: [edge.source],
       targets: [edge.target],
     })),
@@ -617,12 +620,12 @@ export const getLayoutedElements = (nodes: ITableData, edges: Edge[]) => {
     .layout(graph)
     .then((layoutedGraph) => {
       const flattenedNodes = flattenNodes(layoutedGraph.children);
-      const edges = (layoutedGraph.edges || []).map((edge) => ({
+      const edges = (layoutedGraph.edges || []).map((edge: any) => ({
         ...edge,
         id: edge.id,
         source: edge.sources[0],
         target: edge.targets[0],
-        animated: false,
+        animated: edge.animated,
         type: "smoothstep",
         zIndex: 10,
       }));

--- a/view/src/interfaces/DataLayoutsType.ts
+++ b/view/src/interfaces/DataLayoutsType.ts
@@ -24,7 +24,7 @@ export interface IDiagramEdgeMapping {
   name: string;
   labelFormat: string;
   animated: boolean;
-  colorKey: string;
+  legendItems: string;
   sourceKey: string;
   targetKey: string;
 }

--- a/view/src/interfaces/DataLayoutsType.ts
+++ b/view/src/interfaces/DataLayoutsType.ts
@@ -8,8 +8,8 @@ export interface IRowMapping {
 }
 
 export interface IDiagramRowMapping extends IRowMapping {
-  nodeColor: string | string[];
-  nodeTextColor: string | string[];
+  nodeColor: string;
+  nodeTextColor: string;
   nodeType?: string;
   edgeMatchKey?: string;
   subRowMappings?: IDiagramRowMapping[];
@@ -23,6 +23,7 @@ export interface IDiagramEdgeMapping {
   id: string;
   name: string;
   labelFormat: string;
+  animated: boolean;
   colorKey: string;
   sourceKey: string;
   targetKey: string;


### PR DESCRIPTION
## Checklist before submitting a merge request

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md) document
- [x] All commits have been signed-off for the Developer Certificate of Origin. See [here](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
- [x] I have added my contribution to [CHANGELOG.md](https://github.com/opencaesar/oml-vision/blob/master/CHANGELOG.md)
- [x] I have added my documentation to the [OML Vision Docs](http://www.opencaesar.io/oml-vision-docs/)

## Description of contribution

Add ability to for users to animate edges in Diagrams and change `colorKey` property in `edges` to `legendItems`
closes https://github.com/opencaesar/oml-vision/issues/14

## Testing performed

<!-- If needed, describe additional testing that was performed for any changes -->

- [ ] I have added unit tests to cover additional functionality

Testing was done on a code space and tested on open-source-rover OML model
https://github.com/UTNAK/open-source-rover


## Expected functionality changes

- When user adds `animated: true` in the `edges` array then the edges are animated
- When user changes `colorKey` in the `edges` array then the legend still populates with data and the edges are correctly colored

## Additional context

[If needed, you may add additional context]
