### PR TITLE
Feat/19-node-edge-highlights

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 RUN apt-get install -y openjdk-17-jdk
 
 # Install TypeScript and npm
-RUN npm install -g typescript
+RUN npm install -g typescript yarn
 
 # Install Docker
 RUN apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Add VSCode dev container https://github.com/opencaesar/oml-vision/pull/21
 - Add ability to change node and node text color while automatically changing node color based on node type https://github.com/opencaesar/oml-vision/pull/22
 - Add ability to animate edges https://github.com/opencaesar/oml-vision/pull/23
+- Add ability to highlight/unlight connected edges to selected nodes https://github.com/opencaesar/oml-vision/pull/24
 
 ## [0.1.0]
 

--- a/view/src/components/Diagram/Diagram.tsx
+++ b/view/src/components/Diagram/Diagram.tsx
@@ -13,21 +13,21 @@ import ReactFlow, {
   ControlButton,
   MiniMap,
   Panel,
-  Position,
-  Connection,
   useNodesState,
   useEdgesState,
   useReactFlow,
-  ReactFlowState,
   useOnSelectionChange,
   useNodesInitialized,
   NodeProps,
+  getIncomers,
+  getOutgoers,
+  getConnectedEdges,
 } from "reactflow";
 
 // Icons
 import { IconDownload } from "@nasa-jpl/react-stellar";
-import LockIcon from "./Icons/Lock"
-import UnlockIcon from "./Icons/Unlock"
+import LockIcon from "./Icons/Lock";
+import UnlockIcon from "./Icons/Unlock";
 
 import { toPng, toSvg } from "html-to-image";
 import Loader from "../shared/Loader";
@@ -78,6 +78,76 @@ function Diagram({
       }
     },
   });
+
+  const highlightPath = (
+    selectedNodes: Node[],
+    nodes: Node[],
+    edges: Edge[]
+  ) => {
+
+    // Empty Node[] to capture all selected incoming and outgoing nodes
+    let allIncomers: Node[] = [];
+    let allOutgoers: Node[] = [];
+
+    // Loop over selected nodes to find all incoming and outgoing nodes.  Push to empty lists
+    for (const n of selectedNodes) {
+      const incomers = getIncomers(n, nodes, edges);
+      const outgoers = getOutgoers(n, nodes, edges);
+      allIncomers.push(...incomers)
+      allOutgoers.push(...outgoers)
+    }
+    
+    // Find the connected edges to the incoming and outgoing nodes
+    const in_connected = getConnectedEdges(allIncomers, edges);
+    const out_connected = getConnectedEdges(allOutgoers, edges);
+
+    // Determine the edges that are not connected to any incoming or outgoing selected nodes
+    let notConnected = edges.filter(e => !in_connected.some(in_e => in_e.id === e.id));
+    notConnected = edges.filter(e => !out_connected.some(out_e => out_e.id === e.id));
+
+    // Set the opacity of those edges to 25%
+    notConnected.map(n => {
+      n.style = {
+        ...n.style,
+        opacity: 0.25,
+      }
+    })
+
+    // Set the opacity of incoming edges to 25%
+    in_connected.map(i => {
+      i.style = {
+        ...i.style,
+        opacity: 1,
+      }
+    })
+
+    // Set the opacity of outgoing edges to 25%
+    out_connected.map(o => {
+      o.style = {
+        ...o.style,
+        opacity: 1,
+      }
+    })
+
+    // Combine the arrays while ensuring uniqueness based on the 'id' property
+    const combinedArray = Array.from(new Set([...notConnected, ...out_connected, ...in_connected]));
+
+    setEdges([...combinedArray]);
+  };
+
+  const unHighlightPath = (
+    edges: Edge[]
+  ) => {
+    // Set the opacity of all edges to 100%
+    edges.map(e => {
+      e.style = {
+        ...e.style,
+        opacity: 1,
+      }
+    })
+
+    setEdges([...edges]);
+  };
 
   const onLayout = useCallback(
     ({ useInitialNodes = true }: { useInitialNodes?: boolean }) => {
@@ -184,6 +254,14 @@ function Diagram({
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
+        onSelectionChange={(selectedElements) => {
+          setSelectedNodes(selectedElements.nodes)
+          if (selectedNodes.length > 0) highlightPath(selectedNodes, nodes, edges)
+        }}
+        onPaneClick={() => {
+          setSelectedNodes([])
+          unHighlightPath(edges)
+        }}
         proOptions={{ hideAttribution: true }}
         nodeTypes={nodeTypes}
         nodesConnectable={false}

--- a/view/src/pages/HomeView.tsx
+++ b/view/src/pages/HomeView.tsx
@@ -81,7 +81,7 @@ const HomeView: React.FC<{}> = () => {
 
         {/* top-right text */}
         <h1 className="absolute top-0 right-2.5 text-lg text-[color:var(--vscode-settings-textInputForeground)]">{title}</h1><br/>
-        <h3 className="absolute bottom-0 right-2.5 text-xs text-[color:var(--vscode-settings-textInputForeground)]"><IconVisibleShow className="inline" /> v{version}</h3>
+        <h3 className="absolute bottom-0 right-2.5 text-xs text-[color:var(--vscode-settings-textInputForeground)]"><IconVisibleShow className="inline" /> {version}</h3>
       </div>
 
       {/* Links for each view */}


### PR DESCRIPTION
## Checklist before submitting a merge request

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md) document
- [x] All commits have been signed-off for the Developer Certificate of Origin. See [here](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
- [x] I have added my contribution to [CHANGELOG.md](https://github.com/opencaesar/oml-vision/blob/master/CHANGELOG.md)

## Description of contribution

Add ability to change node and node text color while automatically changing node color based on node type 

closes https://github.com/opencaesar/oml-vision/issues/19

## Testing performed

<!-- If needed, describe additional testing that was performed for any changes -->

- [ ] I have added unit tests to cover additional functionality

Testing was done on a code space and tested on open-source-rover OML model
https://github.com/UTNAK/open-source-rover


## Expected functionality changes

When user clicks a node then its connected edges are highlighted and when the user clicks off of the node then edges return to normal.

## Additional context

[If needed, you may add additional context]
