### PR TITLE
Feat/17-auto-layout-diagram

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,10 +15,11 @@
 
 - [ ] I have added unit tests to cover additional functionality
 
+## How to Test Expected functionality changes
 
-## Expected functionality changes
+[Describe expected behaviour changes in steps]
 
-[Describe expected behaviour changes]
+- [ ] I have added the steps needed to test these changes
 
 ## Additional context
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [v0.2.0]
 
 ### Fixed
-- Tree View shows VSCode error popup with Tree UI bugs https://github.com/opencaesar/oml-vision/pull/5
+- Tree View: shows VSCode error popup with Tree UI bugs https://github.com/opencaesar/oml-vision/pull/5
 
 ### Added
-- Add export to SVG for diagrams https://github.com/opencaesar/oml-vision/pull/3
-- Add VSCode dev container https://github.com/opencaesar/oml-vision/pull/21
-- Add ability to change node and node text color while automatically changing node color based on node type https://github.com/opencaesar/oml-vision/pull/22
-- Add ability to animate edges https://github.com/opencaesar/oml-vision/pull/23
-- Add ability to highlight/unlight connected edges to selected nodes https://github.com/opencaesar/oml-vision/pull/24
+- Diagram View: Add export to SVG for diagrams https://github.com/opencaesar/oml-vision/pull/3
+- Developer Experience: Add VSCode dev container https://github.com/opencaesar/oml-vision/pull/21
+- Diagram View: Add ability to change node and node text color while automatically changing node color based on node type https://github.com/opencaesar/oml-vision/pull/22
+- Diagram View: Add ability to animate edges https://github.com/opencaesar/oml-vision/pull/23
+- Diagram View: Add ability to highlight/unlight connected edges to selected nodes https://github.com/opencaesar/oml-vision/pull/24
+- Diagram View: Add ability to automatically apply a position layout to nodes and edges https://github.com/opencaesar/oml-vision/pull/24
 
 ## [0.1.0]
 

--- a/view/src/components/Diagram/Diagram.tsx
+++ b/view/src/components/Diagram/Diagram.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useRef,
   useLayoutEffect,
+  ChangeEvent,
 } from "react";
 import ReactFlow, {
   Node,
@@ -64,6 +65,7 @@ function Diagram({
   clearFilter: Function;
   onNodeSelected?: Function;
 }) {
+  // Vanilla React Hooks
   const [isLoading, setIsLoading] = useState(true);
   const [autoLayout, setAutoLayout] = useState("");
   const diagramRef = useRef<HTMLDivElement>(null);
@@ -173,7 +175,7 @@ function Diagram({
         }
       });
     },
-    [initData, nodes, edges]
+    [initData, nodes, edges, autoLayout]
   );
 
   const getNodeColor = (node: Node) => {
@@ -247,6 +249,115 @@ function Diagram({
     );
   }
 
+  // References the setAutoLayout function
+  // https://stackoverflow.com/questions/7969088/when-do-i-use-parentheses-and-when-do-i-not
+  const handleSetAutoLayout = (e: ChangeEvent<HTMLSelectElement>) => {
+    setAutoLayout(e.target.value);
+  };
+
+  const selectedAutoLayout = (autoLayout: string) => {
+    let dropDownOptions = null;
+    switch (autoLayout) {
+      case "left": {
+        dropDownOptions = (
+          <div className="flex items-center z-10 space-x-2 p-2 rounded shadow-md bg-[var(--vscode-banner-background)]">
+            <span slot="auto-layout">Auto Layout</span>
+            <VSCodeDropdown
+              // @ts-ignore
+              onChange={handleSetAutoLayout}
+            >
+              <VSCodeOption selected value="left">
+                Left
+              </VSCodeOption>
+              <VSCodeOption value="right">Right</VSCodeOption>
+              <VSCodeOption value="top">Top</VSCodeOption>
+              <VSCodeOption value="bottom">Bottom</VSCodeOption>
+            </VSCodeDropdown>
+          </div>
+        );
+        break;
+      }
+      case "right": {
+        dropDownOptions = (
+          <div className="flex items-center z-10 space-x-2 p-2 rounded shadow-md bg-[var(--vscode-banner-background)]">
+            <span slot="auto-layout">Auto Layout</span>
+            <VSCodeDropdown
+              // @ts-ignore
+              onChange={handleSetAutoLayout}
+            >
+              <VSCodeOption value="left">Left</VSCodeOption>
+              <VSCodeOption selected value="right">
+                Right
+              </VSCodeOption>
+              <VSCodeOption value="top">Top</VSCodeOption>
+              <VSCodeOption value="bottom">Bottom</VSCodeOption>
+            </VSCodeDropdown>
+          </div>
+        );
+        break;
+      }
+      case "top": {
+        dropDownOptions = (
+          <div className="flex items-center z-10 space-x-2 p-2 rounded shadow-md bg-[var(--vscode-banner-background)]">
+            <span slot="auto-layout">Auto Layout</span>
+            <VSCodeDropdown
+              // @ts-ignore
+              onChange={handleSetAutoLayout}
+            >
+              <VSCodeOption value="left">Left</VSCodeOption>
+              <VSCodeOption value="right">Right</VSCodeOption>
+              <VSCodeOption selected value="top">
+                Top
+              </VSCodeOption>
+              <VSCodeOption value="bottom">Bottom</VSCodeOption>
+            </VSCodeDropdown>
+          </div>
+        );
+        break;
+      }
+      case "bottom": {
+        dropDownOptions = (
+          <div className="flex items-center z-10 space-x-2 p-2 rounded shadow-md bg-[var(--vscode-banner-background)]">
+            <span slot="auto-layout">Auto Layout</span>
+            <VSCodeDropdown
+              // @ts-ignore
+              onChange={handleSetAutoLayout}
+            >
+              <VSCodeOption value="left">Left</VSCodeOption>
+              <VSCodeOption value="right">Right</VSCodeOption>
+              <VSCodeOption value="top">Top</VSCodeOption>
+              <VSCodeOption selected value="bottom">
+                Bottom
+              </VSCodeOption>
+            </VSCodeDropdown>
+          </div>
+        );
+        break;
+      }
+      default: {
+        // Default dropDownOptions to select position as "left"
+        dropDownOptions = (
+          <div className="flex items-center z-10 space-x-2 p-2 rounded shadow-md bg-[var(--vscode-banner-background)]">
+            <span slot="auto-layout">Auto Layout</span>
+            <VSCodeDropdown
+              // @ts-ignore
+              onChange={handleSetAutoLayout}
+            >
+              <VSCodeOption selected value="left">
+                Left
+              </VSCodeOption>
+              <VSCodeOption value="right">Right</VSCodeOption>
+              <VSCodeOption value="top">Top</VSCodeOption>
+              <VSCodeOption value="bottom">Bottom</VSCodeOption>
+            </VSCodeDropdown>
+          </div>
+        );
+        break;
+      }
+    }
+    return dropDownOptions;
+  };
+
   return (
     <div
       className="w-screen h-screen"
@@ -306,20 +417,7 @@ function Diagram({
           </div>
         </Panel>
         <Panel className="flow-panel" position="top-center">
-          <div className="flex items-center z-10 space-x-2 p-2 rounded shadow-md bg-[var(--vscode-banner-background)]">
-            <span slot="auto-layout">Auto Layout</span>
-            <VSCodeDropdown
-              // @ts-ignore
-              onChange={(select: React.FormEvent<HTMLInputElement>) =>
-                setAutoLayout(select.currentTarget.value)
-              }
-            >
-              <VSCodeOption value="left">Left</VSCodeOption>
-              <VSCodeOption value="right">Right</VSCodeOption>
-              <VSCodeOption value="top">Top</VSCodeOption>
-              <VSCodeOption value="bottom">Bottom</VSCodeOption>
-            </VSCodeDropdown>
-          </div>
+          {selectedAutoLayout(autoLayout)}
         </Panel>
         <Controls className="flow-controls" showInteractive={false}>
           {/* Implemented custom interactive button to avoid disabling selection in diagram */}


### PR DESCRIPTION
## Checklist before submitting a merge request

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md) document
- [x] All commits have been signed-off for the Developer Certificate of Origin. See [here](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
- [x] I have added my contribution to [CHANGELOG.md](https://github.com/opencaesar/oml-vision/blob/master/CHANGELOG.md)

## Description of contribution

Add ability to change node and node text color while automatically changing node color based on node type 

closes https://github.com/opencaesar/oml-vision/issues/17

## Testing performed

<!-- If needed, describe additional testing that was performed for any changes -->

- [ ] I have added unit tests to cover additional functionality

Testing was done on a code space and tested on open-source-rover OML model
https://github.com/UTNAK/open-source-rover


## Expected functionality changes

When user clicks the `Auto Layout` dropdown in the diagram view then the nodes and edges in the diagram are positioned with the selected position in the dropdown.

## Additional context

<img width="1840" alt="image" src="https://github.com/opencaesar/oml-vision/assets/108915844/f9b76450-0f61-42a0-9d18-4b9b8912c5ee">

