### PR TITLE
Fix/36-multiple-children-objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable changes to the "oml-vision" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [v0.3.0]
+## v0.3.0 - Venus
+
+## v0.2.5 - Caloris Basin
+
+### Fixed
+- Table, Tree, and Diagram Views: cannot generate a view when there are more than 2 sets of layouts objects that contain the "children" attribute in the pages.json file https://github.com/opencaesar/oml-vision/pull/37
 
 ### Added
 - Table, Tree, and Diagram Views: refactor layouts to support viewpoint definitions for each page https://github.com/opencaesar/oml-vision/pull/33
 - Sidebar: add UI indication that data has been loaded into Fuseki RDF Triplestore https://github.com/opencaesar/oml-vision/pull/34
+- Tree View: add ability to specify and edits columns https://github.com/opencaesar/oml-vision/pull/36
 
-## [v0.2.0]
+## v0.2.0 - Mercury
 
 ### Fixed
 - Tree View: shows VSCode error popup with Tree UI bugs https://github.com/opencaesar/oml-vision/pull/5
@@ -24,7 +30,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Diagram View: Add ability to automatically apply a position layout to nodes and edges https://github.com/opencaesar/oml-vision/pull/25
 - Diagram View: Add ability to apply a layout algorithm to nodes and edges https://github.com/opencaesar/oml-vision/pull/27
 
-## [0.1.0]
+## 0.1.0
 
 ### Added
 - Initial release

--- a/view/src/pages/DiagramView.tsx
+++ b/view/src/pages/DiagramView.tsx
@@ -30,17 +30,19 @@ const DiagramView: React.FC = () => {
 
     let diagramLayouts: any = {};
 
-    // layouts[LayoutPaths.Pages][1]["children"] comes from pages.json file structure and key-value pairs
-    layouts[LayoutPaths.Pages][1]["children"].forEach((diagram: any) => {
-      if (diagram.type === "diagram") {
-        // Locally scoped variable which is used to set the key of the JSON object
-        let _path = "";
-        // Path comes from the pages.json file with the .json file identifier
-        _path = diagram.path + ".json";
-        // Use object spread to merge all diagrams into diagramLayouts object
-        diagramLayouts = {...diagramLayouts, ...layouts[_path]};
-      }
-    });
+    // layouts[LayoutPaths.Pages] comes from the pages.json file structure and key-value pairs
+    layouts[LayoutPaths.Pages].forEach((layout: any) => {
+      layout.children?.forEach((page: any) => {
+        if (page.type === "diagram") {
+          // Locally scoped variable which is used to set the key of the JSON object
+          let _path = "";
+          // Path comes from the pages.json file with the .json file identifier
+          _path = page.path + ".json";
+          // Use object spread to merge all tables into tableLayouts object
+          diagramLayouts = { ...diagramLayouts, ...layouts[_path] };
+        }
+      });
+    })
 
     const root = document.getElementById("root");
     let webviewPath = root?.getAttribute("data-webview-path") || "";

--- a/view/src/pages/TableView.tsx
+++ b/view/src/pages/TableView.tsx
@@ -24,17 +24,19 @@ const TableView: React.FC = () => {
 
     let tableLayouts: any = {};
 
-    // layouts[LayoutPaths.Pages][1]["children"] comes from pages.json file structure and key-value pairs
-    layouts[LayoutPaths.Pages][1]["children"].forEach((table: any) => {
-      if (table.type === "table") {
-        // Locally scoped variable which is used to set the key of the JSON object
-        let _path = "";
-        // Path comes from the pages.json file with the .json file identifier
-        _path = table.path + ".json";
-        // Use object spread to merge all tables into tableLayouts object
-        tableLayouts = { ...tableLayouts, ...layouts[_path] };
-      }
-    });
+    // layouts[LayoutPaths.Pages] comes from the pages.json file structure and key-value pairs
+    layouts[LayoutPaths.Pages].forEach((layout: any) => {
+      layout.children?.forEach((page: any) => {
+        if (page.type === "table") {
+          // Locally scoped variable which is used to set the key of the JSON object
+          let _path = "";
+          // Path comes from the pages.json file with the .json file identifier
+          _path = page.path + ".json";
+          // Use object spread to merge all tables into tableLayouts object
+          tableLayouts = { ...tableLayouts, ...layouts[_path] };
+        }
+      });
+    })
 
     const root = document.getElementById("root");
     let webviewPath = root?.getAttribute("data-webview-path") || "";

--- a/view/src/pages/TreeView.tsx
+++ b/view/src/pages/TreeView.tsx
@@ -26,17 +26,19 @@ const TreeView: React.FC = () => {
 
     let treeLayouts: any = {};
 
-    // layouts[LayoutPaths.Pages][1]["children"] comes from pages.json file structure and key-value pairs
-    layouts[LayoutPaths.Pages][1]["children"].forEach((tree: any) => {
-      if (tree.type === "tree") {
-        // Locally scoped variable which is used to set the key of the JSON object
-        let _path = "";
-        // Path comes from the pages.json file with the .json file identifier
-        _path = tree.path + ".json";
-        // Use object spread to merge all trees into treeLayouts object
-        treeLayouts = { ...treeLayouts, ...layouts[_path] };
-      }
-    });
+    // layouts[LayoutPaths.Pages] comes from the pages.json file structure and key-value pairs
+    layouts[LayoutPaths.Pages].forEach((layout: any) => {
+      layout.children?.forEach((page: any) => {
+        if (page.type === "tree") {
+          // Locally scoped variable which is used to set the key of the JSON object
+          let _path = "";
+          // Path comes from the pages.json file with the .json file identifier
+          _path = page.path + ".json";
+          // Use object spread to merge all tables into tableLayouts object
+          treeLayouts = { ...treeLayouts, ...layouts[_path] };
+        }
+      });
+    })
 
     const root = document.getElementById("root");
     let webviewPath = root?.getAttribute("data-webview-path") || "";


### PR DESCRIPTION
## Checklist before submitting a merge request

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md) document
- [x] All commits have been signed-off for the Developer Certificate of Origin. See [here](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
- [x] I have added my contribution to [CHANGELOG.md](https://github.com/opencaesar/oml-vision/blob/master/CHANGELOG.md)
- [x] I have documented my code in the [OML Vision Docs](http://www.opencaesar.io/oml-vision-docs/)

## Description of contribution

Fix bug with generated a view with 2 sets of layout objects that contain the 'children' attribute

closes https://github.com/opencaesar/oml-vision/issues/36
 
## Testing performed

<!-- If needed, describe additional testing that was performed for any changes -->

- [x] I have added unit tests to cover additional functionality

## How to Test Expected functionality changes

OML Model:
1. You can use this OML model for testing https://github.com/pogi7/kepler16b-example
2.  Update the `src/vision/pages.json` file to look like this.  PLEASE DON'T COMMIT/PUSH THIS CHANGE.:
```json
[
  { "title": "Home", "path": "/", "type": "home" },
  {
    "title": "Kepler16b",
    "type": "group",
    "iconUrl": "https://nasa-jpl.github.io/stellar/icons/satellite.svg",
    "children": [
      { 
        "title": "Objectives",
        "type": "table",
        "path": "objectives"
      },
      {
        "title": "Missions",
        "type": "tree",
        "path": "missions"
      },
      {
        "title": "Components",
        "type": "diagram",
        "path": "components"
      }
    ]
  },
  {
    "title": "Test",
    "type": "group",
    "iconUrl": "https://nasa-jpl.github.io/stellar/icons/satellite.svg",
    "children": [
      {
        "title": "Requirements",
        "type": "tree",
        "path": "requirements"
      },
      {
        "title": "Connections",
        "type": "table",
        "path": "connections"
      }
    ]
  }
]
```
3. Click the OML Vision eye icon
4. Verify that all views can open when clicking them in the Home page or in sidebar

## Additional context

