### PR TITLE
Feat/29-property-sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Look at the OML Vision Docs [Changelog](http://www.opencaesar.io/oml-vision-docs
 
 ## v0.3.0 - Venus
 
+### Added
+- Property View: Allows users to see the properties of elements selected in the webview https://github.com/opencaesar/oml-vision/pull/42
+
 ### Modified
 - Viewpoints: Listen to viewpoints directory instead of layouts directory (Change layouts directory to viewpoints directory) https://github.com/opencaesar/oml-vision/issues/40
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Look at the OML Vision Docs [Changelog](http://www.opencaesar.io/oml-vision-docs
 
 ## v0.3.0 - Venus
 
+## v0.2.6 - Rembrandt Basin
+
 ### Added
 - Property View: Allows users to see the properties of elements selected in the webview https://github.com/opencaesar/oml-vision/pull/42
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Look at the OML Vision Docs [Changelog](http://www.opencaesar.io/oml-vision-docs
 
 ## v0.3.0 - Venus
 
+### Modified
+- Viewpoints: Listen to viewpoints directory instead of layouts directory (Change layouts directory to viewpoints directory) https://github.com/opencaesar/oml-vision/issues/40
+
 ## v0.2.5 - Caloris Basin
 
 ### Fixed

--- a/commands/src/commands.ts
+++ b/commands/src/commands.ts
@@ -7,17 +7,17 @@ export enum Commands {
   INFORM = "inform",
 
   // Table Panel Commands
-  CREATE_TABLE = "createTable",
-  ROW_CLICKED = "rowClicked",
-  HIDE_PROPERTIES = "hideProperties",
-  ASK_FOR_LAYOUTS = "askForLayouts",
-  GENERATE_TABLE_DATA = "generateTableData",
-  UPDATE_CM_STATE = "updateCmState",
-  REFRESH_TABLE_DATA = "refreshTableData",
-  GET_ELEMENT_DEPENDENCIES = "getElementDependencies",
-  EXECUTE_CREATE_ELEMENTS = "executeCreateElements",
-  EXECUTE_DELETE_ELEMENTS = "executeDeleteElements",
-  CREATE_FCR = "createFCR",
+  CREATE_TABLE = 'createTable',
+  ROW_CLICKED = 'rowClicked',
+  HIDE_PROPERTIES = 'hideProperties',
+  ASK_FOR_VIEWPOINTS = 'askForViewpoints',
+  GENERATE_TABLE_DATA = 'generateTableData',
+  UPDATE_CM_STATE = 'updateCmState',
+  REFRESH_TABLE_DATA = 'refreshTableData',
+  GET_ELEMENT_DEPENDENCIES = 'getElementDependencies',
+  EXECUTE_CREATE_ELEMENTS = 'executeCreateElements',
+  EXECUTE_DELETE_ELEMENTS = 'executeDeleteElements',
+  CREATE_FCR = 'createFCR',
 
   // Property Panel Commands
   ASK_FOR_PROPERTIES = "askForProperties",
@@ -36,17 +36,17 @@ export enum Commands {
   PING_TRIPLESTORE_TASK = "pingTriplestoreTask",
 
   // Extension To Table Panel Commands
-  UPDATE_LOCAL_VALUE = "updateLocalValue",
-  SEND_LAYOUTS = "sendLayouts",
-  OPEN_WIZARD = "openWizard",
-  CREATE_FILTERED_DIAGRAM = "createFilteredDiagram",
-  LOADED_PROPERTY_SHEET = "loadedPropertySheet",
-  LOADED_TABLE_DATA = "loadedTableData",
-  LOADED_ELEMENT_DEPENDENCIES = "loadedElementDependencies",
-  DELETED_ELEMENTS = "deletedElements",
-  CREATED_ELEMENT = "createdElement",
-  CLONED_ELEMENTS = "clonedElements",
-  SHOW_PROPERTIES = "showProperties",
+  UPDATE_LOCAL_VALUE = 'updateLocalValue',
+  SEND_VIEWPOINTS = 'sendViewpoints',
+  OPEN_WIZARD = 'openWizard',
+  CREATE_FILTERED_DIAGRAM = 'createFilteredDiagram',
+  LOADED_PROPERTY_SHEET = 'loadedPropertySheet',
+  LOADED_TABLE_DATA = 'loadedTableData',
+  LOADED_ELEMENT_DEPENDENCIES = 'loadedElementDependencies',
+  DELETED_ELEMENTS = 'deletedElements',
+  CREATED_ELEMENT = 'createdElement',
+  CLONED_ELEMENTS = 'clonedElements',
+  SHOW_PROPERTIES = 'showProperties',
 }
 
 export type CommandStructures = {
@@ -63,7 +63,7 @@ export type CommandStructures = {
     payload: string;
   };
   [Commands.HIDE_PROPERTIES]: {};
-  [Commands.ASK_FOR_LAYOUTS]: {};
+  [Commands.ASK_FOR_VIEWPOINTS]: {};
   [Commands.GENERATE_TABLE_DATA]: {
     payload: { webviewPath: string; queries: Record<string, string> };
     wizardId?: string;
@@ -121,8 +121,8 @@ export type CommandStructures = {
     };
   };
   [Commands.UPDATE_LOCAL_VALUE]: {};
-  [Commands.SEND_LAYOUTS]: {
-    payload: { [filename: string]: Record<string, string> | any[] };
+  [Commands.SEND_VIEWPOINTS]: {
+    payload: { [filename: string]: Record<string, string> | any[] }
   };
   [Commands.OPEN_WIZARD]: {
     payload: {

--- a/commands/src/interfaces/ViewpointPaths.ts
+++ b/commands/src/interfaces/ViewpointPaths.ts
@@ -1,5 +1,5 @@
 /**
- * Defines name of file for layout path.
+ * Defines name of file for viewpoint path.
  *
  *
  * @deprecated Hardcoded names of files will be dynamically generated from the vision directory in the model
@@ -7,7 +7,7 @@
  * @todo Remove in v1.0.0 of OML Vision
  */
 // TODO: Remove in v1.0.0 of OML Vision
-export enum LayoutPaths {
+export enum ViewpointPaths {
   PropertyPanel = 'propertyLayouts.json',
   TablePanel = 'tableLayouts.json',
   TreePanel = 'treeLayouts.json',

--- a/commands/src/propertyPanelMessageHandler.ts
+++ b/commands/src/propertyPanelMessageHandler.ts
@@ -27,9 +27,9 @@ export function handlePropertyPanelMessage(
       vscode.commands.executeCommand("oml-vision.sendPropertiesToPanel");
       return;
 
-    case Commands.ASK_FOR_LAYOUTS:
+    case Commands.ASK_FOR_VIEWPOINTS:
       vscode.commands.executeCommand(
-        "oml-vision.sendLayouts",
+        "oml-vision.sendViewpoints",
         PropertyPanelInstance
       );
       return;

--- a/commands/src/tablePanelMessageHandler.ts
+++ b/commands/src/tablePanelMessageHandler.ts
@@ -45,9 +45,9 @@ export function handleTablePanelMessage(
       vscode.commands.executeCommand("oml-vision.hideProperties");
       break;
 
-    case Commands.ASK_FOR_LAYOUTS:
+    case Commands.ASK_FOR_VIEWPOINTS:
       vscode.commands.executeCommand(
-        "oml-vision.sendLayouts",
+        "oml-vision.sendViewpoints",
         TablePanel.currentPanels.get(TablePanelInstance.getWebviewType().path)
       );
       break;

--- a/controller/src/panels/PropertyPanelProvider.ts
+++ b/controller/src/panels/PropertyPanelProvider.ts
@@ -13,7 +13,7 @@ import {
   CommandDefinitions,
   Commands,
 } from "../../../commands/src/commands";
-import { globalLayoutContents } from "../extension";
+import { globalViewpointContents } from "../extension";
 /**
  * Manages react-based webview for the Property page
  */
@@ -103,10 +103,10 @@ export class PropertyPanelProvider implements WebviewViewProvider {
     }
   }
 
-  public static updateLayouts() {
+  public static updateViewpoints() {
     this._instance?.sendMessage({
-      command: Commands.SEND_LAYOUTS,
-      payload: globalLayoutContents,
+      command: Commands.SEND_VIEWPOINTS,
+      payload: globalViewpointContents,
     });
   }
 }

--- a/controller/src/panels/TablePanel.ts
+++ b/controller/src/panels/TablePanel.ts
@@ -14,7 +14,7 @@ import {
   CommandDefinitions,
   Commands,
 } from "../../../commands/src/commands";
-import { globalLayoutContents } from "../extension";
+import { globalViewpointContents } from "../extension";
 
 /**
  * Manages react-based webview panels for a Table
@@ -155,11 +155,11 @@ export class TablePanel {
     );
   }
 
-  public static updateLayouts() {
+  public static updateViewpoints() {
     TablePanel.currentPanels.forEach((panel) =>
       panel.sendMessage({
-        command: Commands.SEND_LAYOUTS,
-        payload: globalLayoutContents,
+        command: Commands.SEND_VIEWPOINTS,
+        payload: globalViewpointContents,
       })
     );
   }

--- a/controller/src/sidebar/TreeDataProvider.ts
+++ b/controller/src/sidebar/TreeDataProvider.ts
@@ -12,13 +12,13 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
 
   public static getInstance(
     hasBuildFolder: boolean = false,
-    hasPageLayout: boolean = false,
+    hasPageViewpoint: boolean = false,
     hasSparqlConfig: boolean = false
   ): TreeDataProvider {
     if (this._instance === null) {
       this._instance = new TreeDataProvider(
         hasBuildFolder,
-        hasPageLayout,
+        hasPageViewpoint,
         hasSparqlConfig
       );
     }
@@ -27,16 +27,16 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
 
   data: TreeItem[];
   private _hasBuildFolder: boolean;
-  private _hasPageLayout: boolean;
+  private _hasPageViewpoint: boolean;
   private _hasSparqlConfig: boolean;
 
   private constructor(
     hasBuildFolder: boolean,
-    hasPageLayout: boolean,
+    hasPageViewpoint: boolean,
     hasSparqlConfig: boolean
   ) {
     this._hasBuildFolder = hasBuildFolder;
-    this._hasPageLayout = hasPageLayout;
+    this._hasPageViewpoint = hasPageViewpoint;
     this._hasSparqlConfig = hasSparqlConfig;
     this.data = buildTreeItems();
   }
@@ -57,13 +57,13 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
   getChildren(
     element?: TreeItem | undefined
   ): vscode.ProviderResult<TreeItem[]> {
-    if (this._hasBuildFolder && this._hasPageLayout && this._hasSparqlConfig) {
+    if (this._hasBuildFolder && this._hasPageViewpoint && this._hasSparqlConfig) {
       if (element === undefined) {
         return this.data;
       }
       return element.children;
     } else {
-      // If there's no build folder or no page layout, return an empty array to trigger the welcome view.
+      // If there's no build folder or no page viewpoint, return an empty array to trigger the welcome view.
       return [];
     }
   }
@@ -74,9 +74,9 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
     this._onDidChangeTreeData.fire(undefined);
   }
 
-  updateHasPageLayout(hasPageLayout: boolean) {
-    this._hasPageLayout = hasPageLayout;
-    // This will refresh the tree items pages view in the sidebar.
+  updateHasPageViewpoint(hasPageViewpoint: boolean) {
+    this._hasPageViewpoint = hasPageViewpoint;
+    // This will refresh the sidebar pages view.
     this._onDidChangeTreeData.fire(undefined);
   }
 
@@ -86,8 +86,8 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
     this._onDidChangeTreeData.fire(undefined);
   }
 
-  updateLayouts(pageLayout: (IWebviewType | ITableCategory)[]) {
-    this.data = buildTreeItems(pageLayout);
+  updateViewpoints(pageViewpoint: (IWebviewType | ITableCategory)[]) {
+    this.data = buildTreeItems(pageViewpoint);
     // This will refresh the tree items pages view in the sidebar.
     this._onDidChangeTreeData.fire(undefined);
   }

--- a/controller/src/sparql/SparqlClient.ts
+++ b/controller/src/sparql/SparqlClient.ts
@@ -27,7 +27,9 @@ export async function SparqlClient(query: string, service: SparqlServiceType, ir
   
   if (!QUERY) {
     QUERY = query
-    vscode.window.showWarningMessage(`SPARQL query not defined in src/vision/sparql directory: ${query}`);
+    // Uncomment to have VSCode notify users about SPARQL query not being defined in src/vision/sparql directory
+    // More info here https://code.visualstudio.com/api/ux-guidelines/notifications
+    // vscode.window.showWarningMessage(`SPARQL query not defined in src/vision/sparql directory: ${query}`);
     console.warn(`SPARQL query not defined in src/vision/sparql directory: ${query}`)
   };
 

--- a/controller/src/utilities/loaders/loadSparqlConfigFiles.ts
+++ b/controller/src/utilities/loaders/loadSparqlConfigFiles.ts
@@ -12,7 +12,7 @@ export async function loadSparqlConfigFiles() {
     const workspaceFolders = workspace.workspaceFolders;
     if (workspaceFolders) {
       const uri = workspaceFolders[0].uri;
-      const layoutsFolderUri = Uri.joinPath(
+      const configFolderUri = Uri.joinPath(
         uri,
         "src",
         "vision",
@@ -20,11 +20,11 @@ export async function loadSparqlConfigFiles() {
       );
   
       try {
-        const files = await workspace.fs.readDirectory(layoutsFolderUri);
+        const files = await workspace.fs.readDirectory(configFolderUri);
   
         for (const [file, type] of files) {
           if (file.endsWith(".json") && type === FileType.File) {
-            const fileUri = Uri.joinPath(layoutsFolderUri, file);
+            const fileUri = Uri.joinPath(configFolderUri, file);
             const buffer = await workspace.fs.readFile(fileUri);
             try {
               const content: Record<string,string> = JSON.parse(buffer.toString());

--- a/controller/src/utilities/loaders/loadViewpointFiles.ts
+++ b/controller/src/utilities/loaders/loadViewpointFiles.ts
@@ -5,28 +5,28 @@ import { PropertyPanelProvider } from "../../panels/PropertyPanelProvider";
 // TODO: handle multiple workspaces (currently assumes model is in the 1st)
 
 /**
- * Loads JSON files that are stored in the layouts folder of the model.
+ * Loads JSON files that are stored in the viewpoints folder of the model.
  *
  * @remarks
  * This method uses the workspace class from the {@link https://code.visualstudio.com/api/references/vscode-api | VSCode API}.
  *
- * @param layoutContents - content of the layout object
+ * @param viewpointContents - content of the viewpoint object
  *
  */
-export const loadLayoutFiles = async (layoutContents: {
+export const loadViewpointFiles = async (viewpointContents: {
   [file: string]: any;
 }) => {
-  commands.executeCommand("setContext", "vision:hasPageLayout", false);
-  TreeDataProvider.getInstance().updateHasPageLayout(false);
+  commands.executeCommand("setContext", "vision:hasPageViewpoint", false);
+  TreeDataProvider.getInstance().updateHasPageViewpoint(false);
 
   const workspaceFolders = workspace.workspaceFolders;
   if (workspaceFolders) {
     const uri = workspaceFolders[0].uri;
-    loadPageFile(uri, layoutContents);
-    loadTableFiles(uri, layoutContents);
-    loadTreeFiles(uri, layoutContents);
-    loadDiagramFiles(uri, layoutContents);
-    loadPropertyFiles(uri, layoutContents);
+    loadPageFile(uri, viewpointContents);
+    loadTableFiles(uri, viewpointContents);
+    loadTreeFiles(uri, viewpointContents);
+    loadDiagramFiles(uri, viewpointContents);
+    loadPropertyFiles(uri, viewpointContents);
   }
 };
 
@@ -37,17 +37,17 @@ export const loadLayoutFiles = async (layoutContents: {
  * This method uses the workspace class from the {@link https://code.visualstudio.com/api/references/vscode-api | VSCode API}.
  *
  * @param uri - A universal resource identifier representing either a file on disk or another resource, like untitled resources.
- * @param layoutContents - content of the layout object
+ * @param viewpointContents - content of the viewpoint object
  *
  */
 const loadPageFile = async (
   uri: Uri,
-  layoutContents: {
+  viewpointContents: {
     [file: string]: any;
   }
 ) => {
   // Uri is required for VSCode extension to determine path to file or folder
-  const pageFolderUri = Uri.joinPath(uri, "src", "vision", "layouts");
+  const pageFolderUri = Uri.joinPath(uri, "src", "vision", "viewpoints");
 
   try {
     const files = await workspace.fs.readDirectory(pageFolderUri);
@@ -57,13 +57,13 @@ const loadPageFile = async (
         const buffer = await workspace.fs.readFile(fileUri);
         const content = JSON.parse(buffer.toString());
         try {
-          TreeDataProvider.getInstance().updateLayouts(content);
-          TreeDataProvider.getInstance().updateHasPageLayout(true);
-          layoutContents[file] = content;
+          TreeDataProvider.getInstance().updateViewpoints(content);
+          TreeDataProvider.getInstance().updateHasPageViewpoint(true);
+          viewpointContents[file] = content;
         } catch (parseErr) {
-          layoutContents = {};
+          viewpointContents = {};
           throw new Error(
-            `Error parsing table layout file ${file}: ${parseErr}`
+            `Error parsing table viewpoint file ${file}: ${parseErr}`
           );
         }
       }
@@ -71,28 +71,28 @@ const loadPageFile = async (
   } catch (err) {
     if (
       err instanceof Error &&
-      err.message.startsWith("Error parsing layout file")
+      err.message.startsWith("Error parsing viewpoint file")
     )
       window.showErrorMessage(err.message);
     else {
-      window.showErrorMessage(`Error reading layout files: ${err}`);
+      window.showErrorMessage(`Error reading viewpoint files: ${err}`);
     }
   }
 };
 
 /**
- * Loads table layouts from the tables directory.
+ * Loads table viewpoints from the tables directory.
  *
  * @remarks
  * This method uses the workspace class from the {@link https://code.visualstudio.com/api/references/vscode-api | VSCode API}.
  *
  * @param uri - A universal resource identifier representing either a file on disk or another resource, like untitled resources.
- * @param layoutContents - content of the layout object
+ * @param viewpointContents - content of the viewpoint object
  *
  */
 const loadTableFiles = async (
   uri: Uri,
-  layoutContents: {
+  viewpointContents: {
     [file: string]: any;
   }
 ) => {
@@ -101,7 +101,7 @@ const loadTableFiles = async (
     uri,
     "src",
     "vision",
-    "layouts",
+    "viewpoints",
     "tables"
   );
 
@@ -109,92 +109,102 @@ const loadTableFiles = async (
     const files = await workspace.fs.readDirectory(tableFolderUri);
     for (const [file, type] of files) {
       if (file.endsWith(".json") && type === FileType.File) {
-        setLayoutContent(tableFolderUri, file, layoutContents);
+        setviewpointContent(tableFolderUri, file, viewpointContents);
       }
     }
     if (files.length > 0) {
-      commands.executeCommand("setContext", "vision:hasPageLayout", true);
-      window.showInformationMessage("Table Layout files loaded successfully.");
+      commands.executeCommand("setContext", "vision:hasPageViewpoint", true);
+      window.showInformationMessage(
+        "Table viewpoint files loaded successfully."
+      );
     } else {
-      window.showWarningMessage("Table Layout files not found.");
+      window.showWarningMessage("Table viewpoint files not found.");
     }
   } catch (err) {
     if (
       err instanceof Error &&
-      err.message.startsWith("Error parsing table layout file")
+      err.message.startsWith("Error parsing table viewpoint file")
     )
       window.showErrorMessage(err.message);
     else {
-      window.showErrorMessage(`Error reading table layout files: ${err}`);
+      window.showErrorMessage(`Error reading table viewpoint files: ${err}`);
     }
   } finally {
-    // Send updated global layouts to TablePanels & PropertyPanel
-    TablePanel.updateLayouts();
-    PropertyPanelProvider.updateLayouts();
+    // Send updated global viewpoints to TablePanels & PropertyPanel
+    TablePanel.updateViewpoints();
+    PropertyPanelProvider.updateViewpoints();
   }
 };
 
 /**
- * Loads tree layouts from the trees directory.
+ * Loads tree viewpoints from the trees directory.
  *
  * @remarks
  * This method uses the workspace class from the {@link https://code.visualstudio.com/api/references/vscode-api | VSCode API}.
  *
  * @param uri - A universal resource identifier representing either a file on disk or another resource, like untitled resources.
- * @param layoutContents - content of the layout object
+ * @param viewpointContents - content of the viewpoint object
  *
  */
 const loadTreeFiles = async (
   uri: Uri,
-  layoutContents: {
+  viewpointContents: {
     [file: string]: any;
   }
 ) => {
   // Uri is required for VSCode extension to determine path to file or folder
-  const treeFolderUri = Uri.joinPath(uri, "src", "vision", "layouts", "trees");
+  const treeFolderUri = Uri.joinPath(
+    uri,
+    "src",
+    "vision",
+    "viewpoints",
+    "trees"
+  );
 
   try {
     const files = await workspace.fs.readDirectory(treeFolderUri);
     for (const [file, type] of files) {
       if (file.endsWith(".json") && type === FileType.File) {
-        setLayoutContent(treeFolderUri, file, layoutContents);
+        setviewpointContent(treeFolderUri, file, viewpointContents);
       }
     }
     if (files.length > 0) {
-      commands.executeCommand("setContext", "vision:hasPageLayout", true);
-      window.showInformationMessage("Tree Layout files loaded successfully.");
+      commands.executeCommand("setContext", "vision:hasPageViewpoint", true);
+      window.showInformationMessage(
+        "Tree viewpoint files loaded successfully."
+      );
     } else {
-      window.showWarningMessage("Tree Layout files not found.");
+      window.showWarningMessage("Tree viewpoint files not found.");
     }
   } catch (err) {
     if (
       err instanceof Error &&
-      err.message.startsWith("Error parsing tree layout file")
+      err.message.startsWith("Error parsing tree viewpoint file")
     )
       window.showErrorMessage(err.message);
     else {
-      window.showErrorMessage(`Error reading tree layout files: ${err}`);
+      window.showErrorMessage(`Error reading tree viewpoint files: ${err}`);
     }
   } finally {
-    // Send updated global layouts to TablePanels & PropertyPanel
-    TablePanel.updateLayouts();
-    PropertyPanelProvider.updateLayouts();
+    // Send updated global viewpoints to TablePanels & PropertyPanel
+    TablePanel.updateViewpoints();
+    PropertyPanelProvider.updateViewpoints();
   }
 };
 
 /**
- * Loads diagram layouts from the diagrams directory.
+ * Loads diagram viewpoints from the diagrams directory.
  *
  * @remarks
  * This method uses the workspace class from the {@link https://code.visualstudio.com/api/references/vscode-api | VSCode API}.
  *
  * @param uri - A universal resource identifier representing either a file on disk or another resource, like untitled resources.
- * @param layoutContents - content of the layout object
+ * @param viewpointContents - content of the viewpoint object
  *
  */
 const loadDiagramFiles = async (
   uri: Uri,
-  layoutContents: {
+  viewpointContents: {
     [file: string]: any;
   }
 ) => {
@@ -203,7 +213,7 @@ const loadDiagramFiles = async (
     uri,
     "src",
     "vision",
-    "layouts",
+    "viewpoints",
     "diagrams"
   );
 
@@ -211,39 +221,39 @@ const loadDiagramFiles = async (
     const files = await workspace.fs.readDirectory(diagramFolderUri);
     for (const [file, type] of files) {
       if (file.endsWith(".json") && type === FileType.File) {
-        setLayoutContent(diagramFolderUri, file, layoutContents);
+        setviewpointContent(diagramFolderUri, file, viewpointContents);
       }
     }
     if (files.length > 0) {
-      commands.executeCommand("setContext", "vision:hasPageLayout", true);
+      commands.executeCommand("setContext", "vision:hasPageViewpoint", true);
       window.showInformationMessage(
-        "Diagram Layout files loaded successfully."
+        "Diagram viewpoint files loaded successfully."
       );
     } else {
-      window.showWarningMessage("Diagram Layout files not found.");
+      window.showWarningMessage("Diagram viewpoint files not found.");
     }
   } catch (err) {
-    window.showErrorMessage(`Error reading diagram layout files: ${err}`);
+    window.showErrorMessage(`Error reading diagram viewpoint files: ${err}`);
   } finally {
-    // Send updated global layouts to TablePanels & PropertyPanel
-    TablePanel.updateLayouts();
-    PropertyPanelProvider.updateLayouts();
+    // Send updated global viewpoints to TablePanels & PropertyPanel
+    TablePanel.updateViewpoints();
+    PropertyPanelProvider.updateViewpoints();
   }
 };
 
 /**
- * Loads property layouts from the properties directory.
+ * Loads property viewpoints from the properties directory.
  *
  * @remarks
  * This method uses the workspace class from the {@link https://code.visualstudio.com/api/references/vscode-api | VSCode API}.
  *
  * @param uri - A universal resource identifier representing either a file on disk or another resource, like untitled resources.
- * @param layoutContents - content of the layout object
+ * @param viewpointContents - content of the viewpoint object
  *
  */
 const loadPropertyFiles = async (
   uri: Uri,
-  layoutContents: {
+  viewpointContents: {
     [file: string]: any;
   }
 ) => {
@@ -252,7 +262,7 @@ const loadPropertyFiles = async (
     uri,
     "src",
     "vision",
-    "layouts",
+    "viewpoints",
     "properties"
   );
 
@@ -260,45 +270,45 @@ const loadPropertyFiles = async (
     const files = await workspace.fs.readDirectory(propertyFolderUri);
     for (const [file, type] of files) {
       if (file.endsWith(".json") && type === FileType.File) {
-        setLayoutContent(propertyFolderUri, file, layoutContents);
+        setviewpointContent(propertyFolderUri, file, viewpointContents);
       }
     }
     if (files.length > 0) {
-      commands.executeCommand("setContext", "vision:hasPageLayout", true);
+      commands.executeCommand("setContext", "vision:hasPageViewpoint", true);
       window.showInformationMessage(
-        "Property Layout files loaded successfully."
+        "Property viewpoint files loaded successfully."
       );
     } else {
-      window.showWarningMessage("Property Layout files not found.");
+      window.showWarningMessage("Property viewpoint files not found.");
     }
   } catch (err) {
-    window.showErrorMessage(`Error reading property layout files: ${err}`);
+    window.showErrorMessage(`Error reading property viewpoint files: ${err}`);
   } finally {
-    // Send updated global layouts to TablePanels & PropertyPanel
-    TablePanel.updateLayouts();
-    PropertyPanelProvider.updateLayouts();
+    // Send updated global viewpoints to TablePanels & PropertyPanel
+    TablePanel.updateViewpoints();
+    PropertyPanelProvider.updateViewpoints();
   }
 };
 
 /**
- * Set the Layout Content.
+ * Set the viewpoint Content.
  *
  * @remarks
  * This method uses the URI class from the {@link https://code.visualstudio.com/api/references/vscode-api | VSCode API}.
  *
  * @param uri - A universal resource identifier representing either a file on disk or another resource, like untitled resources.
  * @param file - The file name.
- * @param layouts - The layouts object which will be set.
+ * @param viewpoints - The viewpoints object which will be set.
  *
  */
-const setLayoutContent = async (uri: Uri, file: string, layouts: any) => {
+const setviewpointContent = async (uri: Uri, file: string, viewpoints: any) => {
   const fileUri = Uri.joinPath(uri, file);
   const buffer = await workspace.fs.readFile(fileUri);
   const content = JSON.parse(buffer.toString());
   try {
-    layouts[file] = content;
+    viewpoints[file] = content;
   } catch (parseErr) {
-    layouts = {};
-    throw new Error(`Error parsing table layout file ${file}: ${parseErr}`);
+    viewpoints = {};
+    throw new Error(`Error parsing table viewpoint file ${file}: ${parseErr}`);
   }
 };

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
       {
         "view": "vision-webview-pages",
         "contents": "No pages available in the build folder. Run ./gradlew build.",
-        "when": "!vision:hasBuildFolder || !vision:hasLayoutFiles || !vision:hasSparqlConfig"
+        "when": "!vision:hasBuildFolder || !vision:hasViewpointFiles || !vision:hasSparqlConfig"
       }
     ],
     "views": {

--- a/view/src/App.tsx
+++ b/view/src/App.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { MemoryRouter, Navigate, Routes, Route } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PropertiesDataProvider } from "./contexts/PropertyDataProvider";
-import { LayoutPaths, useLayoutData } from "./contexts/LayoutProvider";
+import { ViewpointPaths, useLayoutData } from "./contexts/LayoutProvider";
 import HomeView from "./pages/HomeView";
 import TableView from "./pages/TableView";
 import TreeView from "./pages/TreeView";
@@ -28,10 +28,11 @@ const App = () => {
     </WizardsProvider>
   );
 
-  // Generate routes from property layout data
+  // Generate routes from property layout data in src/vision/layouts/properties folder in OML model
   const propertyLayout = (layouts[
-    LayoutPaths.PropertyPanel
+    ViewpointPaths.PropertyPanel
   ] as PropertyLayout) ?? { pages: [] };
+
   const propertyRoutes = propertyLayout.pages.map((page: PropertyPage) => (
     <Route
       key={page.id}

--- a/view/src/components/Diagram/Diagram.tsx
+++ b/view/src/components/Diagram/Diagram.tsx
@@ -53,7 +53,9 @@ function Diagram({
   webviewPath,
   hasFilter,
   clearFilter = () => {},
+  // TODO: Use onNodeSelected while node is highlighted/selected
   onNodeSelected = () => {},
+  onNodeClicked = () => {},
 }: {
   initData: {
     nodes: ITableData[];
@@ -64,6 +66,7 @@ function Diagram({
   hasFilter: boolean;
   clearFilter: Function;
   onNodeSelected?: Function;
+  onNodeClicked?: Function;
 }) {
   // Vanilla React Hooks
   const [isLoading, setIsLoading] = useState(true);
@@ -78,14 +81,21 @@ function Diagram({
   const { isInteractive, setInteractivity, toggleInteractivity } =
     useCanvasInteractivity();
 
-  useOnSelectionChange({
-    onChange: ({ nodes, edges }) => {
-      setSelectedNodes(nodes);
-      if (nodes.length === 1) {
-        onNodeSelected(nodes[0]);
-      }
-    },
-  });
+  // FIXME: useOnSelectionChange occurs after a selection occurs and will continously running when clicking a node or edge
+  // useOnSelectionChange({
+  //   onChange: ({ nodes, edges }) => {
+  //     setSelectedNodes(nodes);
+  //     if (nodes.length === 1) {
+  //       onNodeClicked(nodes[0]);
+  //       onNodeSelected(nodes[0]);
+  //     }
+  //   },
+  // });
+
+  // Handles when a node is clicked.  Note accessing properties is handled in DiagramView.tsx
+  const onNodeClick = (event: any, node: any) => {
+    onNodeClicked(node);
+  };
 
   const highlightPath = (
     selectedNodes: Node[],
@@ -471,6 +481,7 @@ function Diagram({
           setSelectedNodes([]);
           unHighlightPath(edges);
         }}
+        onNodeClick={onNodeClick}
         proOptions={{ hideAttribution: true }}
         nodeTypes={nodeTypes}
         nodesConnectable={false}

--- a/view/src/components/PropertySheet.tsx
+++ b/view/src/components/PropertySheet.tsx
@@ -1,25 +1,21 @@
-import React, { useEffect, useState, useRef, KeyboardEvent } from 'react';
-import {
-  IconPlus,
-  IconMinus,
-  FormField
-} from '@nasa-jpl/react-stellar';
+import React, { useEffect, useState, useRef, KeyboardEvent } from "react";
+import { IconPlus, IconMinus, FormField } from "@nasa-jpl/react-stellar";
 import {
   VSCodeTextField,
   VSCodeRadioGroup,
-  VSCodeRadio
-} from '@vscode/webview-ui-toolkit/react';
-import { useForm, FieldValues } from 'react-hook-form';
-import { parse, EvalAstFactory } from 'jexpr';
-import { postMessage } from '../utils/postMessage';
-import { usePropertiesData } from '../contexts/PropertyDataProvider';
-import ITableData from '../interfaces/ITableData';
-import { PropertyPage } from '../interfaces/PropertyLayoutsType';
-import { CMStatesArray } from '../interfaces/CMStates';
-import { IDisplayGroup } from '../interfaces/IDisplayGroup';
-import HelpIcon from './shared/HelpIcon';
-import Loader from './shared/Loader';
-import { CommandStructures, Commands } from '../../../commands/src/commands';
+  VSCodeRadio,
+} from "@vscode/webview-ui-toolkit/react";
+import { useForm, FieldValues } from "react-hook-form";
+import { parse, EvalAstFactory } from "jexpr";
+import { postMessage } from "../utils/postMessage";
+import { usePropertiesData } from "../contexts/PropertyDataProvider";
+import ITableData from "../interfaces/ITableData";
+import { PropertyPage } from "../interfaces/PropertyLayoutsType";
+import { CMStatesArray } from "../interfaces/CMStates";
+import { IDisplayGroup } from "../interfaces/IDisplayGroup";
+import HelpIcon from "./shared/HelpIcon";
+import Loader from "./shared/Loader";
+import { CommandStructures, Commands } from "../../../commands/src/commands";
 
 const astFactory = new EvalAstFactory();
 const isDataEmpty = (obj: Object) => Object.keys(obj).length === 0;
@@ -45,7 +41,8 @@ const PropertySheet: React.FC<{ page: PropertyPage }> = ({ page }) => {
 
       let specificMessage;
       if (message.command === Commands.LOADED_PROPERTY_SHEET) {
-        specificMessage = message as CommandStructures[Commands.LOADED_PROPERTY_SHEET];
+        specificMessage =
+          message as CommandStructures[Commands.LOADED_PROPERTY_SHEET];
         if (specificMessage.errorMessage) {
           console.error(specificMessage.errorMessage);
           setErrorMessage(specificMessage.errorMessage);
@@ -56,15 +53,15 @@ const PropertySheet: React.FC<{ page: PropertyPage }> = ({ page }) => {
         try {
           const results = specificMessage.payload;
 
-          if (!results || typeof results !== 'object') {
-            throw new Error('Invalid JSON format: expected an object');
+          if (!results || typeof results !== "object") {
+            throw new Error("Invalid JSON format: expected an object");
           }
 
           const sparqlData = results || [];
           const omlData = sparqlData.length > 0 ? sparqlData[0] : {};
           setData(omlData);
         } catch (error) {
-          let errorMessage = '';
+          let errorMessage = "";
           if (error instanceof SyntaxError) {
             errorMessage = `Failed to parse JSON data: ${error.message}`;
           } else {
@@ -81,9 +78,9 @@ const PropertySheet: React.FC<{ page: PropertyPage }> = ({ page }) => {
         setIsLoading(false);
       }
     };
-    window.addEventListener('message', handler);
+    window.addEventListener("message", handler);
     return () => {
-      window.removeEventListener('message', handler);
+      window.removeEventListener("message", handler);
     };
   }, []);
 
@@ -100,21 +97,28 @@ const PropertySheet: React.FC<{ page: PropertyPage }> = ({ page }) => {
 
       // Generate displayGroups based on current tableRowTypes
       const evaluatedExpressions = page.groups
-        .filter(group => group.displayExpression).map((expression) => {
+        .filter((group) => group.displayExpression)
+        .map((expression) => {
           let display: boolean;
           try {
             const expr = parse(expression.displayExpression!, astFactory);
-            if (!expr) { throw new Error(`Invalid expression: ${expression.displayExpression}`); }
+            if (!expr) {
+              throw new Error(
+                `Invalid expression: ${expression.displayExpression}`
+              );
+            }
             display = expr.evaluate({ tableRowTypes });
           } catch (error) {
-            console.error(`Failed to evaluate display expression for group ${expression.id}: ${error}`);
+            console.error(
+              `Failed to evaluate display expression for group ${expression.id}: ${error}`
+            );
             display = false;
           }
 
           // Return an object that matches the DisplayGroup interface
           return {
             id: expression.id,
-            display
+            display,
           };
         });
       setDisplayGroups(evaluatedExpressions);
@@ -124,7 +128,7 @@ const PropertySheet: React.FC<{ page: PropertyPage }> = ({ page }) => {
         payload: {
           queryName: page.sparqlQuery,
           iri: rowIri,
-        }
+        },
       });
     }
   }, [rowIri, tableRowTypes, isAvailable]);
@@ -135,12 +139,11 @@ const PropertySheet: React.FC<{ page: PropertyPage }> = ({ page }) => {
       setIsOpen(Array(layoutData.groups.length).fill(true));
 
       // Prepopulate form fields
-      Object.keys(data).forEach(key => {
+      Object.keys(data).forEach((key) => {
         setValue(key, data[key]);
       });
     }
   }, [layoutData, setValue, data]);
-
 
   const handleToggle = (index: number) => {
     const newIsOpen = [...isOpen];
@@ -160,7 +163,7 @@ const PropertySheet: React.FC<{ page: PropertyPage }> = ({ page }) => {
   };
 
   const blurIfReturned = (event: KeyboardEvent) => {
-    if (event.key === 'Enter' && event.target instanceof HTMLElement) {
+    if (event.key === "Enter" && event.target instanceof HTMLElement) {
       (event.target as HTMLElement).blur();
     }
   };
@@ -168,27 +171,39 @@ const PropertySheet: React.FC<{ page: PropertyPage }> = ({ page }) => {
   if (isLoading) {
     return (
       <div className="h-screen flex justify-center">
-        <Loader message={`Loading ${page.label.toLowerCase()} property sheet...`} />
+        <Loader
+          message={`Loading ${page.label.toLowerCase()} property sheet...`}
+        />
       </div>
     );
   }
 
   return (
     <form className="w-full" ref={formRef} onSubmit={handleSubmit(onSubmit)}>
-      {(!layoutData || !layoutData.groups.length || isDataEmpty(data) || errorMessage) ? (
-        <div className='h-screen flex justify-center items-center'>
-          <p className='text-[color:var(--vscode-foreground)]'>{errorMessage ? errorMessage : "Uh oh, no editable properties found!"}</p>
+      {!layoutData ||
+      !layoutData.groups.length ||
+      isDataEmpty(data) ||
+      errorMessage ? (
+        <div className="h-screen flex justify-center items-center">
+          <p className="text-[color:var(--vscode-foreground)]">
+            {errorMessage
+              ? errorMessage
+              : "Uh oh, no editable properties found!"}
+          </p>
         </div>
       ) : (
         <div className="pb-4">
           {layoutData.groups.map((group, index) => {
-
             // Checks if this group is in displayGroups. If it is, we use the display prop (true/false)
             // If not, we default to true because only groups with displayExpressions are optionally displayed
-            const groupInDisplayGroups = displayGroups.find(x => x.id == group.id);
+            const groupInDisplayGroups = displayGroups.find(
+              (x) => x.id == group.id
+            );
             const isConditionalGroup = group.displayExpression;
             // If groupInDisplayGroups not found, ONLY display group if it is not a conditional group (ex. Instance, etc.)
-            const shouldDisplay = groupInDisplayGroups ? groupInDisplayGroups.display : !isConditionalGroup;
+            const shouldDisplay = groupInDisplayGroups
+              ? groupInDisplayGroups.display
+              : !isConditionalGroup;
 
             if (shouldDisplay) {
               return (
@@ -198,8 +213,7 @@ const PropertySheet: React.FC<{ page: PropertyPage }> = ({ page }) => {
                     flex items-center w-full px-2 py-1 rounded
                     bg-[color:var(--vscode-list-dropBackground)]
                     hover:text-[color:var(--vscode-list-activeSelectionForeground)]
-                    active:bg-[color:var(--vscode-list-activeSelectionBackground)]`
-                    }
+                    active:bg-[color:var(--vscode-list-activeSelectionBackground)]`}
                     onClick={() => handleToggle(index)}
                   >
                     {isOpen[index] ? (
@@ -220,23 +234,39 @@ const PropertySheet: React.FC<{ page: PropertyPage }> = ({ page }) => {
                   {isOpen[index] && (
                     <div className="mx-3 mt-4">
                       {group.controls.map((control, idx) => (
-                        <div className="flex items-center my-2 min-w-fit" key={idx}>
+                        <div
+                          className="flex items-center my-2 min-w-fit"
+                          key={idx}
+                        >
                           <label className="basis-2/12 text-[color:var(--vscode-foreground)]">
                             {control.label}
                           </label>
                           <div className="basis-1/12 justify-center">
-                            {control.helpExpression && <HelpIcon helpText={control.helpExpression} />}
+                            {control.helpExpression && (
+                              <HelpIcon helpText={control.helpExpression} />
+                            )}
                           </div>
                           <FormField flow="vertical" className="basis-9/12">
-                            {control.type === "text" && <VSCodeTextField className="vscode-input-rounded" readOnly={control.readOnly} {...register(control.id, { onChange: submitForm })} onKeyUp={blurIfReturned} />}
+                            {control.type === "text" && (
+                              <VSCodeTextField
+                                className="vscode-input-rounded"
+                                readOnly={control.readOnly}
+                                {...register(control.id, {
+                                  onChange: submitForm,
+                                })}
+                                onKeyUp={blurIfReturned}
+                              />
+                            )}
                             {control.type === "radio" && (
                               <FormField flow="vertical" className="basis-9/12">
-                                <VSCodeRadioGroup readOnly={control.readOnly} {...register(control.id, { onChange: submitForm })}>
+                                <VSCodeRadioGroup
+                                  readOnly={control.readOnly}
+                                  {...register(control.id, {
+                                    onChange: submitForm,
+                                  })}
+                                >
                                   {CMStatesArray.map((state, idx) => (
-                                    <VSCodeRadio
-                                      key={idx}
-                                      value={state}
-                                    >
+                                    <VSCodeRadio key={idx} value={state}>
                                       {state}
                                     </VSCodeRadio>
                                   ))}

--- a/view/src/contexts/LayoutProvider.tsx
+++ b/view/src/contexts/LayoutProvider.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useState, useEffect, useContext } from 'react';
-import { LayoutPaths } from '../../../commands/src/interfaces/LayoutPaths';
-export { LayoutPaths } from '../../../commands/src/interfaces/LayoutPaths';
+import { ViewpointPaths } from '../../../commands/src/interfaces/ViewpointPaths';
+export { ViewpointPaths } from '../../../commands/src/interfaces/ViewpointPaths';
 import { postMessage } from '../utils/postMessage';
 import { CommandStructures, Commands } from '../../../commands/src/commands';
 
@@ -24,14 +24,14 @@ export const LayoutProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     const handler = (event: MessageEvent) => {
       const { command, payload } = event.data;
     
-      if (command === Commands.SEND_LAYOUTS) {
-        const layoutContents = payload as CommandStructures[Commands.SEND_LAYOUTS]['payload'];
+      if (command === Commands.SEND_VIEWPOINTS) {
+        const layoutContents = payload as CommandStructures[Commands.SEND_VIEWPOINTS]['payload'];
         let prefixes: Record<string, string> = {};
-    
-        // If LayoutPaths.Prefixes exists in layoutContents, move it to prefixes
-        if (layoutContents.hasOwnProperty(LayoutPaths.Prefixes)) {
-          prefixes = layoutContents[LayoutPaths.Prefixes] as Record<string, string>;
-          delete layoutContents[LayoutPaths.Prefixes]; // Remove it from the layoutContents
+
+        // If ViewpointPaths.Prefixes exists in layoutContents, move it to prefixes
+        if (layoutContents.hasOwnProperty(ViewpointPaths.Prefixes)) {
+          prefixes = layoutContents[ViewpointPaths.Prefixes] as Record<string, string>;
+          delete layoutContents[ViewpointPaths.Prefixes]; // Remove it from the layoutContents
         }
     
         setLayouts({ layouts: layoutContents, prefixes, isLoadingLayoutContext: false });
@@ -41,7 +41,7 @@ export const LayoutProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
     // Ask for data every time the component is mounted or updated
     postMessage({
-      command: Commands.ASK_FOR_LAYOUTS
+      command: Commands.ASK_FOR_VIEWPOINTS
     });
 
     return () => {

--- a/view/src/pages/DiagramView.tsx
+++ b/view/src/pages/DiagramView.tsx
@@ -7,7 +7,7 @@ import ITableData from "../interfaces/ITableData";
 import { mapDiagramValueData } from "../components/Diagram/diagramUtils";
 import { DiagramLayout } from "../interfaces/DataLayoutsType";
 import { ReactFlowProvider } from "reactflow";
-import { LayoutPaths, useLayoutData } from "../contexts/LayoutProvider";
+import { ViewpointPaths, useLayoutData } from "../contexts/LayoutProvider";
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 
 const DiagramView: React.FC = () => {
@@ -31,7 +31,7 @@ const DiagramView: React.FC = () => {
     let diagramLayouts: any = {};
 
     // layouts[LayoutPaths.Pages] comes from the pages.json file structure and key-value pairs
-    layouts[LayoutPaths.Pages].forEach((layout: any) => {
+    layouts[ViewpointPaths.Pages].forEach((layout: any) => {
       layout.children?.forEach((page: any) => {
         if (page.type === "diagram") {
           // Locally scoped variable which is used to set the key of the JSON object

--- a/view/src/pages/DiagramView.tsx
+++ b/view/src/pages/DiagramView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { postMessage } from "../utils/postMessage";
 import { CommandStructures, Commands } from "../../../commands/src/commands";
 import Diagram from "../components/Diagram/Diagram";
@@ -143,10 +143,16 @@ const DiagramView: React.FC = () => {
     );
   }, [data, filter, diagramLayout]);
 
-  const handleClickRow = (tableRow: ITableData) => {
+
+  /**  
+    This function handles when a node is clicked in the Diagram View.  
+    @remarks This method uses the {@link https://react.dev/reference/react/useCallback | useCallback} React hook
+    @param node - The node and its data that is clicked
+  */
+  const handleClickNode = useCallback((node: ITableData) => {
     // Every row should have an IRI, but if somehow it doesn't,
     // hide the properties sheet.
-    if (!tableRow.data.iri) {
+    if (!node.data.iri) {
       postMessage({
         command: Commands.HIDE_PROPERTIES,
       });
@@ -155,9 +161,9 @@ const DiagramView: React.FC = () => {
 
     postMessage({
       command: Commands.ROW_CLICKED,
-      payload: tableRow.data.iri,
+      payload: node.data.iri,
     });
-  };
+  }, []);
 
   const refreshData = () => {
     setIsLoading(true);
@@ -192,7 +198,9 @@ const DiagramView: React.FC = () => {
             webviewPath={webviewPath}
             hasFilter={filter.iris.length > 0}
             clearFilter={() => setFilter({ iris: [], filterObject: null })}
-            onNodeSelected={handleClickRow}
+            onNodeClicked={handleClickNode}
+            // TODO: Use onNodeSelected while node is highlighted/selected
+            onNodeSelected={handleClickNode}
           />
         </ReactFlowProvider>
       ) : (

--- a/view/src/pages/HomeView.tsx
+++ b/view/src/pages/HomeView.tsx
@@ -6,7 +6,7 @@ import { Commands } from "../../../commands/src/commands";
 import { IconVisibleShow, IconSearch } from "@nasa-jpl/react-stellar";
 import Loader from "../components/shared/Loader";
 import { SubmenuData } from "../interfaces/SubmenuData";
-import { LayoutPaths, useLayoutData } from "../contexts/LayoutProvider";
+import { ViewpointPaths, useLayoutData } from "../contexts/LayoutProvider";
 import packageJson from "../../../package.json"
 
 const MAX_SEARCH_SUGGESTIONS = 4;
@@ -23,8 +23,8 @@ const HomeView: React.FC<{}> = () => {
   useEffect(() => {
     if (isLoadingLayoutContext) return;
 
-    const tableLayouts = layouts[LayoutPaths.Pages] ?? [];
-    setSubmenuData(tableLayouts.filter((item: any) => ('title' in item && 'children' in item && 'iconUrl' in item)));
+    const webviewViewpoints = layouts[ViewpointPaths.Pages] ?? [];
+    setSubmenuData(webviewViewpoints.filter((item: any) => ('title' in item && 'children' in item && 'iconUrl' in item)));
     setIsLoading(false);
   }, [layouts, isLoadingLayoutContext]);
 

--- a/view/src/pages/PropertiesView.tsx
+++ b/view/src/pages/PropertiesView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { IconSettings, IconDatabase, IconBranch, IconFilter, IconChecklist, IconLink } from '@nasa-jpl/react-stellar';
+import * as StellarIcons from '@nasa-jpl/react-stellar';
 import { parse, EvalAstFactory } from 'jexpr';
 import NavTab from '../components/shared/NavTab';
 import { usePropertiesData } from '../contexts/PropertyDataProvider';
@@ -9,16 +9,6 @@ import { IDisplayGroup } from '../interfaces/IDisplayGroup';
 
 const astFactory = new EvalAstFactory();
 
-// Icon map for dynamic rendering from layout json
-const ICONS = {
-  IconSettings,
-  IconDatabase,
-  IconBranch,
-  IconFilter,
-  IconChecklist,
-  IconLink,
-  // Add any additional icons you are using here
-}
 
 const PropertiesView: React.FC<{layout: PropertyLayout}> = ({
   layout,
@@ -83,10 +73,11 @@ const PropertiesView: React.FC<{layout: PropertyLayout}> = ({
                 // If pageInDisplayPages not found, ONLY display page if it is not a conditional page
                 const shouldDisplay = pageInDisplayPages ? pageInDisplayPages.display : !isConditionalGroup;
 
-                const IconComponent = page.icon in ICONS ? ICONS[page.icon as keyof typeof ICONS] : null;
+                const IconComponent = page.icon in StellarIcons ? StellarIcons[page.icon as keyof typeof StellarIcons] : null;
                 if (shouldDisplay) return (
                   <li key={page.id}>
                     <NavTab to={`/property-panel/${page.id}`}>
+                      {/* @ts-ignore */}
                       {IconComponent && <IconComponent className="pr-[8px] flex-shrink-0 flex-grow-0 text-[color:var(--vscode-foreground)]" width="20" height="20" />}
                       {page.label}
                     </NavTab>

--- a/view/src/pages/TableView.tsx
+++ b/view/src/pages/TableView.tsx
@@ -7,7 +7,7 @@ import ITableData from "../interfaces/ITableData";
 import { mapValueData } from "../components/Table/tableUtils";
 import { TableLayout } from "../interfaces/DataLayoutsType";
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
-import { LayoutPaths, useLayoutData } from "../contexts/LayoutProvider";
+import { ViewpointPaths, useLayoutData } from "../contexts/LayoutProvider";
 
 const TableView: React.FC = () => {
   const { layouts, isLoadingLayoutContext } = useLayoutData();
@@ -25,7 +25,7 @@ const TableView: React.FC = () => {
     let tableLayouts: any = {};
 
     // layouts[LayoutPaths.Pages] comes from the pages.json file structure and key-value pairs
-    layouts[LayoutPaths.Pages].forEach((layout: any) => {
+    layouts[ViewpointPaths.Pages].forEach((layout: any) => {
       layout.children?.forEach((page: any) => {
         if (page.type === "table") {
           // Locally scoped variable which is used to set the key of the JSON object

--- a/view/src/pages/TableView.tsx
+++ b/view/src/pages/TableView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, MouseEvent } from "react";
+import React, { useState, useEffect, useMemo, MouseEvent, useCallback } from "react";
 import { postMessage } from "../utils/postMessage";
 import { CommandStructures, Commands } from "../../../commands/src/commands";
 import Table from "../components/Table/Table";
@@ -135,13 +135,19 @@ const TableView: React.FC = () => {
     });
   };
 
-  const handleClickRow = (
+  /**  
+    This function handles when a row is clicked in the Table View.  
+    @remarks This method uses the {@link https://react.dev/reference/react/useCallback | useCallback} React hook
+    @param e - The mouse event that React should be listening to
+    @param row - The row and its data that is clicked
+  */
+  const handleClickRow = useCallback((
     e: MouseEvent<HTMLTableRowElement, MouseEvent>,
-    tableRow: ITableData
+    row: ITableData
   ) => {
     // Every row should have an IRI, but if somehow it doesn't,
     // hide the properties sheet.
-    if (!tableRow.original.iri) {
+    if (!row.original.iri) {
       postMessage({
         command: Commands.HIDE_PROPERTIES,
       });
@@ -150,9 +156,9 @@ const TableView: React.FC = () => {
 
     postMessage({
       command: Commands.ROW_CLICKED,
-      payload: tableRow.original.iri,
+      payload: row.original.iri,
     });
-  };
+  }, []);
 
   if (isLoading || isLoadingLayoutContext) {
     return (

--- a/view/src/pages/TreeView.tsx
+++ b/view/src/pages/TreeView.tsx
@@ -9,7 +9,7 @@ import {
   areArraysOfObjectsEqual,
 } from "../components/Tree/treeUtils";
 import { TreeLayout } from "../interfaces/DataLayoutsType";
-import { LayoutPaths, useLayoutData } from "../contexts/LayoutProvider";
+import { ViewpointPaths, useLayoutData } from "../contexts/LayoutProvider";
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 
 const TreeView: React.FC = () => {
@@ -27,7 +27,7 @@ const TreeView: React.FC = () => {
     let treeLayouts: any = {};
 
     // layouts[LayoutPaths.Pages] comes from the pages.json file structure and key-value pairs
-    layouts[LayoutPaths.Pages].forEach((layout: any) => {
+    layouts[ViewpointPaths.Pages].forEach((layout: any) => {
       layout.children?.forEach((page: any) => {
         if (page.type === "tree") {
           // Locally scoped variable which is used to set the key of the JSON object

--- a/view/src/pages/TreeView.tsx
+++ b/view/src/pages/TreeView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, MouseEvent } from "react";
+import React, { useState, useEffect, useMemo, MouseEvent, useCallback } from "react";
 import { postMessage } from "../utils/postMessage";
 import { CommandStructures, Commands } from "../../../commands/src/commands";
 import Tree from "../components/Tree/Tree";
@@ -143,10 +143,15 @@ const TreeView: React.FC = () => {
     });
   };
 
-  const handleClickRow = (tableRow: ITableData) => {
+  /**  
+    This function handles when a row is clicked in the Tree View.  
+    @remarks This method uses the {@link https://react.dev/reference/react/useCallback | useCallback} React hook
+    @param row - The row and its data that is clicked
+  */
+  const handleClickRow = useCallback((row: ITableData) => {
     // Every row should have an IRI, but if somehow it doesn't,
     // hide the properties sheet.
-    if (!tableRow.iri) {
+    if (!row.iri) {
       postMessage({
         command: Commands.HIDE_PROPERTIES,
       });
@@ -155,9 +160,9 @@ const TreeView: React.FC = () => {
 
     postMessage({
       command: Commands.ROW_CLICKED,
-      payload: tableRow.iri,
+      payload: row.iri,
     });
-  };
+  }, []);
 
   if (isLoading || isLoadingLayoutContext) {
     return (


### PR DESCRIPTION
## Checklist before submitting a merge request

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md) document
- [x] All commits have been signed-off for the Developer Certificate of Origin. See [here](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
- [x] I have added my contribution to [CHANGELOG.md](https://github.com/opencaesar/oml-vision/blob/master/CHANGELOG.md)
- [x] I have documented my code in the [OML Vision Docs](http://www.opencaesar.io/oml-vision-docs/)

## Description of contribution

Opens a property sheet when selecting an element in OML Vision

closes https://github.com/opencaesar/oml-vision/issues/29
 
## Testing performed

<!-- If needed, describe additional testing that was performed for any changes -->

- [x] I have added unit tests to cover additional functionality

## How to Test Expected functionality changes

OML Model:
1. You can use this OML model for testing https://github.com/pogi7/kepler16b-example
2. The `propertyLayouts.json` file is already present, but verify that following JSON is defined in the `src/vision/viewpoints/properties/propertyLayouts.json` file.

```json
{
  "pages": [
    {
      "id": "general",
      "label": "General",
      "sparqlQuery": "general-properties.sparql",
      "icon": "IconSettings",
      "groups": [
        {
          "id": "instance",
          "label": "Instance",
          "controls": [
            {
              "type": "text",
              "id": "id",
              "label": "Label",
              "helpExpression": "A label can provide a human-readable id for model objects that have assigned ids that might be less readable"
            },
            {
              "type": "text",
              "id": "anyIri",
              "label": "IRI",
              "readOnly": true,
              "helpExpression": "This is the model-assigned element identifier. Every model element has this unique identifier"
            },
            {
              "type": "text",
              "id": "name",
              "label": "Name",
              "helpExpression": "Lists zero or more model types that this instance specializes. Such supertypes carry inherited properties or relations in the model."
            }
          ]
        }
      ]
    }
  ]
}
```

3. Verify that if you open the `Objectives` table and click the first row, this property sheet pops up (BUG: you may need to click on the row multiple times for the sheet to render properly)
![image](https://github.com/opencaesar/oml-vision/assets/108915844/269093ff-c2e6-4484-8881-7172b768e5ba)
4. Verify that if you open the `Missions` tree and click the first row, this property sheet pops up (BUG: you may need to click on the row multiple times for the sheet to render properly)
![image](https://github.com/opencaesar/oml-vision/assets/108915844/cbc05823-cbd6-4ef4-9a7c-fc6395dbb3bc)
5. Verify that if you open the `Components` diagram and click the `C.02.09` node, this property sheet pops up (BUG: you may need to click on the node multiple times for the sheet to render properly)
![image](https://github.com/opencaesar/oml-vision/assets/108915844/4313edb6-d7ad-408e-96b6-73cc3b71cd0a)


## Additional context

