### PR TITLE
Fix/53-webview-crash-context-menu

### DIFF
--- a/.github/workflows/build_deploy_vsix.yml
+++ b/.github/workflows/build_deploy_vsix.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Build VSIX File
@@ -27,8 +27,8 @@ jobs:
     needs: build_vsix_file
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - uses: actions/download-artifact@v3

--- a/.github/workflows/build_deploy_vsix.yml
+++ b/.github/workflows/build_deploy_vsix.yml
@@ -10,7 +10,7 @@ jobs:
   build_vsix_file:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v1
         with:
           node-version: '18.x'

--- a/.github/workflows/run_controller_test.yml
+++ b/.github/workflows/run_controller_test.yml
@@ -17,7 +17,7 @@ jobs:
   backend_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v1
         with:
           node-version: '18.x'

--- a/.github/workflows/run_controller_test.yml
+++ b/.github/workflows/run_controller_test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Run backend tests

--- a/view/src/components/Diagram/Diagram.tsx
+++ b/view/src/components/Diagram/Diagram.tsx
@@ -607,7 +607,8 @@ function Diagram({
         />
         <Background gap={12} size={1} />
       </ReactFlow>
-      {rightClick && (
+      {/* Check if rightClick and if layout.contextMenu exists */}
+      {rightClick && layout.contextMenu &&(
         <ContextMenu
           selectedElements={iriArray}
           top={coordinates.y}

--- a/view/src/components/Table/Table.tsx
+++ b/view/src/components/Table/Table.tsx
@@ -619,7 +619,7 @@ function Table({
           )}
         </tbody>
       </table>
-      {rightClick && (
+      {rightClick && layout.contextMenu && (
         <ContextMenu
           selectedElements={iriArray}
           top={coordinates.y}

--- a/view/src/components/Tree/Tree.tsx
+++ b/view/src/components/Tree/Tree.tsx
@@ -298,7 +298,7 @@ function Tree({
           </ArboristTree>
         )}
       </FillFlexParent>
-      {rightClick && (
+      {rightClick && layout.contextMenu && (
         <ContextMenu
           selectedElements={iriArray}
           top={coordinates.y}


### PR DESCRIPTION
## Checklist before submitting a merge request

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md) document
- [x] All commits have been signed-off for the Developer Certificate of Origin. See [here](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
- [x] I have added my contribution to [CHANGELOG.md](https://github.com/opencaesar/oml-vision/blob/master/CHANGELOG.md)
- [x] I have documented my code in the [OML Vision Docs](http://www.opencaesar.io/oml-vision-docs/)

## Description of contribution

This fixes the bug where a webview (Table, Tree, or Diagram) crashes when a context menu is not defined.  Bug occurs when a user right clicks in the webview.

## Testing performed

<!-- If needed, describe additional testing that was performed for any changes -->

- [x] I have added unit tests to cover additional functionality (Frontend tests still need to be added)

## How to Test Expected functionality changes

[Describe expected behaviour changes in steps]

1. Go to https://github.com/UTNAK/kepler16b-using-imce-vocabulary
2. Switch to `main` branch
3. Run `git pull`
4. From the command line run `./gradlew load` or from the `Setup Tasks` webview
5. Wait for that command to finish
6. Open the `decompositions-autogen` diagram webview
7. Right click on any node
8. Verify that the diagram webview doesn't crash
9. Open the `Objectives` table webview
10. Right click on any row
11. Verify that the table webview doesn't crash
12. Open the `Requirements` tree webview
13. Right click on any row
14. Verify that the tree webview doesn't crash

## Additional context

[If needed, you may add additional context]
