### PR TITLE
Fix/88-subrowmapping-of-tree-view-doesnt-work-in-some-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Blog: http://www.opencaesar.io/oml-vision-docs/changelog/mars
 - Table and Tree Views: https://github.com/opencaesar/oml-vision/pull/86
 - JSON Validator: https://github.com/opencaesar/oml-vision/issues/74
 
+### Fixed
+- Tree View: https://github.com/opencaesar/oml-vision/pull/89
+
 ## v0.3.0 - Venus
 
 Blog: http://www.opencaesar.io/oml-vision-docs/changelog/venus

--- a/view/src/components/Diagram/diagramUtils.ts
+++ b/view/src/components/Diagram/diagramUtils.ts
@@ -197,7 +197,7 @@ export const mapDiagramValueData = (
           if (parentIri) {
             return row[`${parentId}Iri`] === parentIri;
           } else {
-            return !row["parentIri"];
+            return !row["undefinedIri"];
           }
         })
         // .slice(0, 5)

--- a/view/src/components/Diagram/diagramUtils.ts
+++ b/view/src/components/Diagram/diagramUtils.ts
@@ -195,7 +195,10 @@ export const mapDiagramValueData = (
           // If there's no parentIri specified, we're looking for root nodes
           // If there is a parentIri, we're looking for children of a specific parent
           if (parentIri) {
-            return row[`${parentId}Iri`] === parentIri;
+            // If there is a parentId key in the layout file then attach the row to that parentId
+            if (row[`${parentId}Iri`]) return row[`${parentId}Iri`] === parentIri;
+            // Else have a default parentIri
+            else return row[`parentIri`] === parentIri;
           } else {
             return !row["undefinedIri"];
           }

--- a/view/src/components/Table/tableUtils.ts
+++ b/view/src/components/Table/tableUtils.ts
@@ -64,7 +64,7 @@ export const mapValueData = (
         if (parentIri) {
           return row[`${parentId}Iri`] === parentIri;
         } else {
-          return !row["parentIri"];
+          return !row["undefinedIri"];
         }
       })
       .map((row: ITableData) => {

--- a/view/src/components/Table/tableUtils.ts
+++ b/view/src/components/Table/tableUtils.ts
@@ -62,7 +62,10 @@ export const mapValueData = (
         // If there's no parentIri specified, we're looking for root nodes
         // If there is a parentIri, we're looking for children of a specific parent
         if (parentIri) {
-          return row[`${parentId}Iri`] === parentIri;
+          // If there is a parentId key in the layout file then attach the row to that parentId
+          if (row[`${parentId}Iri`]) return row[`${parentId}Iri`] === parentIri;
+          // Else have a default parentIri
+          else return row[`parentIri`] === parentIri;
         } else {
           return !row["undefinedIri"];
         }

--- a/view/src/components/Tree/treeUtils.ts
+++ b/view/src/components/Tree/treeUtils.ts
@@ -62,7 +62,7 @@ export const mapTreeValueData = (
         if (parentIri) {
           return row[`${parentId}Iri`] === parentIri;
         } else {
-          return !row["parentIri"];
+          return !row["undefinedIri"];
         }
       })
       .map((row: ITableData, index: number) => {

--- a/view/src/components/Tree/treeUtils.ts
+++ b/view/src/components/Tree/treeUtils.ts
@@ -60,7 +60,10 @@ export const mapTreeValueData = (
         // If there's no parentIri specified, we're looking for root nodes
         // If there is a parentIri, we're looking for children of a specific parent
         if (parentIri) {
-          return row[`${parentId}Iri`] === parentIri;
+          // If there is a parentId key in the layout file then attach the row to that parentId
+          if (row[`${parentId}Iri`]) return row[`${parentId}Iri`] === parentIri;
+          // Else have a default parentIri
+          else return row[`parentIri`] === parentIri;
         } else {
           return !row["undefinedIri"];
         }
@@ -95,7 +98,8 @@ export const mapTreeValueData = (
           } else {
             // Handles case where children nodes come from the same query than the parent
             children = rowMapping.subRowMappings.flatMap(
-              (subMapping: IRowMapping) => recursiveMapper(subMapping, identifier=identifier)
+              (subMapping: IRowMapping) =>
+                recursiveMapper(subMapping, (identifier = identifier))
             );
           }
         }


### PR DESCRIPTION
## Checklist before submitting a merge request

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md) document
- [x] All commits have been signed-off for the Developer Certificate of Origin. See [here](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
- [x] I have added my contribution to [CHANGELOG.md](https://github.com/opencaesar/oml-vision/blob/master/CHANGELOG.md)
- [ ] I have documented my code in the [OML Vision Docs](http://www.opencaesar.io/oml-vision-docs/)

## Description of contribution

closes https://github.com/opencaesar/oml-vision/issues/88

## Testing performed

<!-- If needed, describe additional testing that was performed for any changes -->

- [ ] I have added unit tests to cover additional functionality

## How to Test Expected functionality changes

[Describe expected behaviour changes in steps]

1. Use this [model](https://github.com/UTNAK/kepler16b-using-imce-vocabulary) for testing 
2. Open `Requirements` Tree and verify that there are subRowMappings in the Tree
3. Go to the `src/vision/sparql/component_tree_child.sparql` file
4. Change all instances of `subsystemIri` to `parentIri`
5. Verify that the `Component Tree` opens

## Additional context

[If needed, you may add additional context]
